### PR TITLE
Implementing the singleton the right way

### DIFF
--- a/FXKeychain/FXKeychain.m
+++ b/FXKeychain/FXKeychain.m
@@ -44,13 +44,15 @@
 
 + (instancetype)defaultKeychain
 {
-    id sharedInstance = nil;
-    if (!sharedInstance)
-    {
+    static id sharedInstance = nil;
+
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
         NSString *bundleID = [[NSBundle mainBundle] objectForInfoDictionaryKey:(NSString *)kCFBundleIdentifierKey];
         sharedInstance = [[FXKeychain alloc] initWithService:bundleID
                                                  accessGroup:nil];
-    }
+    });
+
     return sharedInstance;
 }
 


### PR DESCRIPTION
`-defaultKeychain` was creating a new object every time, because the variable wasn't static.
It was also not thread safe, so I just used dispatch_once.
