### PR TITLE
Fixing a possible problem when casting objects to chars in ifs and NSAsserts

### DIFF
--- a/FXKeychain/FXKeychain.m
+++ b/FXKeychain/FXKeychain.m
@@ -102,7 +102,7 @@
     }
 
     //fail if object is invalid
-    NSAssert(!object || (object && data), @"FXKeychain failed to encode object for key '%@', error: %@", key, error);
+    NSAssert(object == nil || (object != nil && data != nil), @"FXKeychain failed to encode object for key '%@', error: %@", key, error);
 
     //delete existing data
     OSStatus status = SecItemDelete((__bridge CFDictionaryRef)query);
@@ -170,12 +170,12 @@
             //data represents an NSCoded archive. don't trust it
             object = nil;
         }
-        else if (!object)
+        else if (object == nil)
         {
             //may be a string
             object = [[NSString alloc] initWithData:(__bridge NSData *)data encoding:NSUTF8StringEncoding];
         }
-        if (!object)
+        if (object == nil)
         {
              NSLog(@"FXKeychain failed to decode data for key '%@', error: %@", key, error);
         }

--- a/LICENCE.md
+++ b/LICENCE.md
@@ -1,6 +1,6 @@
 FXKeychain
 
-Version 1.3.2, April 4th, 2013
+Version 1.3.3, April 30th, 2013
 
 Copyright (C) 2012 Charcoal Design
 

--- a/RELEASE NOTES.md
+++ b/RELEASE NOTES.md
@@ -1,3 +1,7 @@
+Version 1.3.3
+
+- Fixed `if (!object)` because it casts the object to char and may lead to a bug with some pointers.
+
 Version 1.3.2
 
 - Now throws an exception if you try to encode an invalid object type instead of merely logging to console


### PR DESCRIPTION
Casting from int to char leads to:

``` objc
const BOOL areEqual = (BOOL)(0xFFFFFF00) == (BOOL)(nil));

NSLog(@"%d", areEqual);
```

```
1
```
