### PR TITLE
Update existing items using SecItemUpdate() instead of deleting

### DIFF
--- a/FXKeychain/FXKeychain.m
+++ b/FXKeychain/FXKeychain.m
@@ -197,7 +197,8 @@
     //recover data
     CFDataRef data = NULL;
     OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, (CFTypeRef *)&data);
-	if (status != errSecSuccess) {
+	
+	if (status != errSecSuccess && status != errSecItemNotFound) {
 		NSLog(@"FXKeychain failed to retrieve data for key '%@', error: %ld", key, (long)status);
 	}
 	return data;


### PR DESCRIPTION
It seems like it would be a better idea to update existing keychain items instead of deleting and recreating them every time. This has the added benefit of solving the OS X bug I [mentioned to you on Twitter](https://twitter.com/indragie/status/342520244889329665) because it bypasses the use of `SecItemDelete()`. 
