### PR TITLE
Avoid logging "failed to delete" error messages

### DIFF
--- a/FXKeychain/FXKeychain.m
+++ b/FXKeychain/FXKeychain.m
@@ -245,7 +245,7 @@
             return NO;
         }
     }
-    else
+    else if (self[key])
     {
         //delete existing data
         


### PR DESCRIPTION
- Only tries to delete an item if it exists in the Keychain. This avoids unnecessary error messages in the console, because this isn't actually an error.

Every time I run my unit tests I get this:

```
FXKeychain failed to delete data for key 'Token', error: -25300
FXKeychain failed to delete data for key 'TokenId', error: -25300
FXKeychain failed to delete data for key 'UserId', error: -25300
```

Because it sets the keys to `nil` and `FXKeychain` tries to delete them w/o checking to see if they exists before. And the logged error messages makes my CI builds report false negatives.
