### PR TITLE
Fixed NSArray pListSerialization crash

### DIFF
--- a/FXKeychain/FXKeychain.m
+++ b/FXKeychain/FXKeychain.m
@@ -306,7 +306,7 @@
                                                                 format:&format
                                                                  error:&error];
             
-            if ([object respondsToSelector:@selector(objectForKey:)] && object[@"$archiver"])
+            if ([object respondsToSelector:@selector(objectForKey:)] && [object objectForKey:@"$archiver"])
             {
                 //data represents an NSCoded archive
                 


### PR DESCRIPTION
App was crashing when retrieving a saved array from the keychain:
`[__NSCFArray objectForKeyedSubscript:]: unrecognized selector sent to instance`

Tracked it down to this line `if ([object respondsToSelector:@selector(objectForKey:)] && object[@"$archiver"])`

The NSArray wasn't liking the subscript, so I changed it to `[object objectForKey:@"$archiver"]`.