### PR TITLE
Added optional NSError parameters to set, get and remove for debugging

### DIFF
--- a/FXKeychain.podspec.json
+++ b/FXKeychain.podspec.json
@@ -1,14 +1,14 @@
 {
   "name": "FXKeychain",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "license": "zlib",
   "summary": "FXKeychain is a lightweight wrapper around the Apple keychain APIs that provides a simple dictionary-like interface.",
   "homepage": "https://github.com/nicklockwood/FXKeychain",
   "authors": "Nick Lockwood",
   "social_media_url": "https://twitter.com/nicklockwood",
   "source": {
-    "git": "https://github.com/nicklockwood/FXKeychain.git",
-    "tag": "1.5.3"
+    "git": "https://github.com/julioacarrettoni/FXKeychain.git",
+    "tag": "1.5.4"
   },
   "source_files": "FXKeychain/FXKeychain.{h,m}",
   "requires_arc": true,

--- a/FXKeychain/FXKeychain.h
+++ b/FXKeychain/FXKeychain.h
@@ -77,12 +77,12 @@ extern NSString * _Nonnull const kFXKeychainErrorDomain;
                   accessGroup:(nullable NSString *)accessGroup;
 
 - (BOOL)setObject:(nullable id)object forKey:(nonnull id)key;
-- (BOOL)setObject:(nullable id)object forKey:(nonnull id)key error:(NSError * _Nullable * _Nullable) error;
+- (BOOL)setObject:(nullable id)object forKey:(nonnull id)key error:(NSError * _Nullable * _Nullable) error NS_SWIFT_NAME(verboseSet(object:key:));
 - (BOOL)setObject:(nullable id)object forKeyedSubscript:(nonnull id)key;
 - (BOOL)removeObjectForKey:(nonnull id)key;
-- (BOOL)removeObjectForKey:(nonnull id)key error:(NSError * _Nullable * _Nullable) error;
+- (BOOL)removeObjectForKey:(nonnull id)key error:(NSError * _Nullable * _Nullable) error NS_SWIFT_NAME(verboseRemove(key:));
 - (nullable id)objectForKey:(nonnull id)key;
-- (nullable id)objectForKey:(nonnull id)key error:(NSError * _Nullable * _Nullable) error;
+- (nullable id)objectForKey:(nonnull id)key error:(NSError * _Nullable * _Nullable) error NS_SWIFT_NAME(verboseObject(key:));
 - (nullable id)objectForKeyedSubscript:(nonnull id)key;
 
 @end

--- a/FXKeychain/FXKeychain.h
+++ b/FXKeychain/FXKeychain.h
@@ -75,9 +75,12 @@ typedef NS_ENUM(NSInteger, FXKeychainAccess)
 - (nonnull id)initWithService:(nullable NSString *)service
                   accessGroup:(nullable NSString *)accessGroup;
 
+- (BOOL)setObject:(nullable id)object forKey:(nonnull id)key;
 - (BOOL)setObject:(nullable id)object forKey:(nonnull id)key error:(NSError * _Nullable * _Nullable) error;
 - (BOOL)setObject:(nullable id)object forKeyedSubscript:(nonnull id)key;
+- (BOOL)removeObjectForKey:(nonnull id)key;
 - (BOOL)removeObjectForKey:(nonnull id)key error:(NSError * _Nullable * _Nullable) error;
+- (nullable id)objectForKey:(nonnull id)key;
 - (nullable id)objectForKey:(nonnull id)key error:(NSError * _Nullable * _Nullable) error;
 - (nullable id)objectForKeyedSubscript:(nonnull id)key;
 

--- a/FXKeychain/FXKeychain.h
+++ b/FXKeychain/FXKeychain.h
@@ -78,7 +78,7 @@ typedef NS_ENUM(NSInteger, FXKeychainAccess)
 - (BOOL)setObject:(nullable id)object forKey:(nonnull id)key;
 - (BOOL)setObject:(nullable id)object forKeyedSubscript:(nonnull id)key;
 - (BOOL)removeObjectForKey:(nonnull id)key;
-- (nullable id)objectForKey:(nonnull id)key;
+- (nullable id)objectForKey:(nonnull id)key error:(NSError * _Nullable * _Nullable) error;
 - (nullable id)objectForKeyedSubscript:(nonnull id)key;
 
 @end

--- a/FXKeychain/FXKeychain.h
+++ b/FXKeychain/FXKeychain.h
@@ -75,9 +75,9 @@ typedef NS_ENUM(NSInteger, FXKeychainAccess)
 - (nonnull id)initWithService:(nullable NSString *)service
                   accessGroup:(nullable NSString *)accessGroup;
 
-- (BOOL)setObject:(nullable id)object forKey:(nonnull id)key;
+- (BOOL)setObject:(nullable id)object forKey:(nonnull id)key error:(NSError * _Nullable * _Nullable) error;
 - (BOOL)setObject:(nullable id)object forKeyedSubscript:(nonnull id)key;
-- (BOOL)removeObjectForKey:(nonnull id)key;
+- (BOOL)removeObjectForKey:(nonnull id)key error:(NSError * _Nullable * _Nullable) error;
 - (nullable id)objectForKey:(nonnull id)key error:(NSError * _Nullable * _Nullable) error;
 - (nullable id)objectForKeyedSubscript:(nonnull id)key;
 

--- a/FXKeychain/FXKeychain.h
+++ b/FXKeychain/FXKeychain.h
@@ -59,6 +59,7 @@ typedef NS_ENUM(NSInteger, FXKeychainAccess)
     FXKeychainAccessibleAlwaysThisDeviceOnly
 };
 
+extern NSString * _Nonnull const kFXKeychainErrorDomain;
 
 @interface FXKeychain : NSObject
 

--- a/FXKeychain/FXKeychain.m
+++ b/FXKeychain/FXKeychain.m
@@ -163,7 +163,7 @@
 	return CFBridgingRelease(data);
 }
 
-- (BOOL)setObject:(id)object forKey:(id)key
+- (BOOL)setObject:(id)object forKey:(id)key error:(NSError**) error
 {
     //generate query
     NSMutableDictionary *query = [NSMutableDictionary dictionary];
@@ -179,7 +179,6 @@
     
     //encode object
     NSData *data = nil;
-    NSError *error = nil;
     if ([(id)object isKindOfClass:[NSString class]])
     {
         //check that string data does not represent a binary plist
@@ -187,7 +186,7 @@
         if (![object hasPrefix:@"bplist"] || ![NSPropertyListSerialization propertyListWithData:[object dataUsingEncoding:NSUTF8StringEncoding]
                                                                                         options:NSPropertyListImmutable
                                                                                          format:&format
-                                                                                          error:NULL])
+                                                                                          error:error])
         {
             //safe to encode as a string
             data = [object dataUsingEncoding:NSUTF8StringEncoding];
@@ -200,7 +199,7 @@
         data = [NSPropertyListSerialization dataWithPropertyList:[object FXKeychain_propertyListRepresentation]
                                                           format:NSPropertyListBinaryFormat_v1_0
                                                          options:0
-                                                           error:&error];
+                                                           error:error];
 #if FXKEYCHAIN_USE_NSCODING
         
         //property list encoding failed. try NSCoding
@@ -214,7 +213,7 @@
     }
 
     //fail if object is invalid
-    NSAssert(!object || (object && data), @"FXKeychain failed to encode object for key '%@', error: %@", key, error);
+    NSAssert(!object || (object && data), @"FXKeychain failed to encode object for key '%@', error: %@", key, *error);
 
     if (data)
     {
@@ -278,12 +277,12 @@
 
 - (BOOL)setObject:(id)object forKeyedSubscript:(id)key
 {
-    return [self setObject:object forKey:key];
+    return [self setObject:object forKey:key error:nil];
 }
 
-- (BOOL)removeObjectForKey:(id)key
+- (BOOL)removeObjectForKey:(id)key error:(NSError **)error
 {
-    return [self setObject:nil forKey:key];
+    return [self setObject:nil forKey:key error:error];
 }
 
 - (id)objectForKey:(id)key error:(NSError**) error

--- a/FXKeychain/FXKeychain.m
+++ b/FXKeychain/FXKeychain.m
@@ -163,6 +163,11 @@
 	return CFBridgingRelease(data);
 }
 
+- (BOOL)setObject:(id)object forKey:(id)key
+{
+    return [self setObject:object forKey:key error:nil];
+}
+
 - (BOOL)setObject:(id)object forKey:(id)key error:(NSError**) error
 {
     //generate query
@@ -277,12 +282,22 @@
 
 - (BOOL)setObject:(id)object forKeyedSubscript:(id)key
 {
-    return [self setObject:object forKey:key error:nil];
+    return [self setObject:object forKey:key];
+}
+
+- (BOOL)removeObjectForKey:(id)key
+{
+    return [self removeObjectForKey:key error:nil];
 }
 
 - (BOOL)removeObjectForKey:(id)key error:(NSError **)error
 {
     return [self setObject:nil forKey:key error:error];
+}
+
+- (id)objectForKey:(id)key
+{
+    return [self objectForKey:key error:nil];
 }
 
 - (id)objectForKey:(id)key error:(NSError**) error
@@ -337,7 +352,7 @@
 
 - (id)objectForKeyedSubscript:(id)key
 {
-    return [self objectForKey:key error:nil];
+    return [self objectForKey:key];
 }
 
 @end

--- a/FXKeychain/FXKeychain.m
+++ b/FXKeychain/FXKeychain.m
@@ -286,13 +286,12 @@
     return [self setObject:nil forKey:key];
 }
 
-- (id)objectForKey:(id)key
+- (id)objectForKey:(id)key error:(NSError**) error
 {
     NSData *data = [self dataForKey:key];
     if (data)
     {
         id object = nil;
-        NSError *error = nil;
         NSPropertyListFormat format = NSPropertyListBinaryFormat_v1_0;
         
         //check if data is a binary plist
@@ -302,7 +301,7 @@
             object = [NSPropertyListSerialization propertyListWithData:data
                                                                options:NSPropertyListImmutable
                                                                 format:&format
-                                                                 error:&error];
+                                                                 error:error];
             
             if ([object respondsToSelector:@selector(objectForKey:)] && [(NSDictionary *)object objectForKey:@"$archiver"])
             {
@@ -326,7 +325,7 @@
         }
         if (!object)
         {
-             NSLog(@"FXKeychain failed to decode data for key '%@', error: %@", key, error);
+             NSLog(@"FXKeychain failed to decode data for key '%@', error: %@", key, *error);
         }
         return object;
     }
@@ -339,7 +338,7 @@
 
 - (id)objectForKeyedSubscript:(id)key
 {
-    return [self objectForKey:key];
+    return [self objectForKey:key error:nil];
 }
 
 @end

--- a/FXKeychain/FXKeychain.m
+++ b/FXKeychain/FXKeychain.m
@@ -160,7 +160,10 @@ NSString * const kFXKeychainErrorDomain = @"FXKeychainErrorDomain";
 	if (status != errSecSuccess && status != errSecItemNotFound)
     {
 		NSLog(@"FXKeychain failed to retrieve data for key '%@', error: %ld", key, (long)status);
-        *error = [NSError errorWithDomain:kFXKeychainErrorDomain code:status userInfo:nil];
+        if (error != NULL)
+        {
+            *error = [NSError errorWithDomain:kFXKeychainErrorDomain code:status userInfo:nil];
+        }
 	}
 	return CFBridgingRelease(data);
 }
@@ -253,7 +256,10 @@ NSString * const kFXKeychainErrorDomain = @"FXKeychainErrorDomain";
         if (status != errSecSuccess)
         {
             NSLog(@"FXKeychain failed to store data for key '%@', error: %ld", key, (long)status);
-            *error = [NSError errorWithDomain:kFXKeychainErrorDomain code:status userInfo:nil];
+            if (error != NULL)
+            {
+                *error = [NSError errorWithDomain:kFXKeychainErrorDomain code:status userInfo:nil];
+            }
             return NO;
         }
     }
@@ -277,7 +283,10 @@ NSString * const kFXKeychainErrorDomain = @"FXKeychainErrorDomain";
         if (status != errSecSuccess)
         {
             NSLog(@"FXKeychain failed to delete data for key '%@', error: %ld", key, (long)status);
-            *error = [NSError errorWithDomain:kFXKeychainErrorDomain code:status userInfo:nil];
+            if (error != NULL)
+            {
+                *error = [NSError errorWithDomain:kFXKeychainErrorDomain code:status userInfo:nil];
+            }
             return NO;
         }
     }


### PR DESCRIPTION
In order to help us find a bug I added this 3 methods so we could extract the NSError while using the keychain and log it on our system not just on NSLog as is happening right now.
- (BOOL)setObject:(nullable id)object forKey:(nonnull id)key error:(NSError \* _Nullable \* _Nullable) error;
- (BOOL)removeObjectForKey:(nonnull id)key error:(NSError \* _Nullable \* _Nullable) error;
- (nullable id)objectForKey:(nonnull id)key error:(NSError \* _Nullable \* _Nullable) error;

The original definition of the methods are still there to maintain backwards compatibility. So the user can still use the library as it was using it and if needed track errors.
