### PR TITLE
Add watchOS and tvOS support to FXKeychain.

### DIFF
--- a/FXKeychain.podspec.json
+++ b/FXKeychain.podspec.json
@@ -14,7 +14,9 @@
   "requires_arc": true,
   "platforms": {
     "ios": "4.3",
-    "osx": "10.6"
+    "osx": "10.6",
+    "watchos": "2.0",
+    "tvos": "9.0"
   },
   "frameworks": "Security"
 }

--- a/FXKeychain.xcodeproj/project.pbxproj
+++ b/FXKeychain.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1F65C92E1D9AFA26002BAC03 /* FXKeychain.m in Sources */ = {isa = PBXBuildFile; fileRef = 72C617371AA394EE0085F425 /* FXKeychain.m */; };
 		72C617211AA3949C0085F425 /* FXKeychain.h in Headers */ = {isa = PBXBuildFile; fileRef = 72C617201AA3949C0085F425 /* FXKeychain.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		72C617381AA394EE0085F425 /* FXKeychain.m in Sources */ = {isa = PBXBuildFile; fileRef = 72C617371AA394EE0085F425 /* FXKeychain.m */; };
 		72C617571AA395470085F425 /* FXKeychain.h in Headers */ = {isa = PBXBuildFile; fileRef = 72C617201AA3949C0085F425 /* FXKeychain.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -14,6 +15,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		1F65C9261D9AF9E6002BAC03 /* FXKeychain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FXKeychain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1F65C9341D9AFA79002BAC03 /* FXKeychain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FXKeychain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		72C6171B1AA3949C0085F425 /* FXKeychain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FXKeychain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		72C6171F1AA3949C0085F425 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		72C617201AA3949C0085F425 /* FXKeychain.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FXKeychain.h; sourceTree = "<group>"; };
@@ -22,6 +25,20 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		1F65C9221D9AF9E6002BAC03 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1F65C9301D9AFA79002BAC03 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		72C617171AA3949C0085F425 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -52,6 +69,8 @@
 			children = (
 				72C6171B1AA3949C0085F425 /* FXKeychain.framework */,
 				72C6173E1AA3951C0085F425 /* FXKeychain.framework */,
+				1F65C9261D9AF9E6002BAC03 /* FXKeychain.framework */,
+				1F65C9341D9AFA79002BAC03 /* FXKeychain.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -77,6 +96,20 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		1F65C9231D9AF9E6002BAC03 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1F65C9311D9AFA79002BAC03 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		72C617181AA3949C0085F425 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -96,6 +129,42 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		1F65C9251D9AF9E6002BAC03 /* FXKeychain-watchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1F65C92D1D9AF9E6002BAC03 /* Build configuration list for PBXNativeTarget "FXKeychain-watchOS" */;
+			buildPhases = (
+				1F65C9211D9AF9E6002BAC03 /* Sources */,
+				1F65C9221D9AF9E6002BAC03 /* Frameworks */,
+				1F65C9231D9AF9E6002BAC03 /* Headers */,
+				1F65C9241D9AF9E6002BAC03 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "FXKeychain-watchOS";
+			productName = "FXKeychain-watchOS";
+			productReference = 1F65C9261D9AF9E6002BAC03 /* FXKeychain.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		1F65C9331D9AFA79002BAC03 /* FXKeychain-tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1F65C9391D9AFA79002BAC03 /* Build configuration list for PBXNativeTarget "FXKeychain-tvOS" */;
+			buildPhases = (
+				1F65C92F1D9AFA79002BAC03 /* Sources */,
+				1F65C9301D9AFA79002BAC03 /* Frameworks */,
+				1F65C9311D9AFA79002BAC03 /* Headers */,
+				1F65C9321D9AFA79002BAC03 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "FXKeychain-tvOS";
+			productName = "FXKeychain-tvOS";
+			productReference = 1F65C9341D9AFA79002BAC03 /* FXKeychain.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		72C6171A1AA3949C0085F425 /* FXKeychain-Mac */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 72C617311AA3949C0085F425 /* Build configuration list for PBXNativeTarget "FXKeychain-Mac" */;
@@ -141,6 +210,14 @@
 				LastUpgradeCheck = 0610;
 				ORGANIZATIONNAME = "Charcoal Design";
 				TargetAttributes = {
+					1F65C9251D9AF9E6002BAC03 = {
+						CreatedOnToolsVersion = 8.0;
+						ProvisioningStyle = Automatic;
+					};
+					1F65C9331D9AFA79002BAC03 = {
+						CreatedOnToolsVersion = 8.0;
+						ProvisioningStyle = Automatic;
+					};
 					72C6171A1AA3949C0085F425 = {
 						CreatedOnToolsVersion = 6.1.1;
 					};
@@ -163,11 +240,27 @@
 			targets = (
 				72C6171A1AA3949C0085F425 /* FXKeychain-Mac */,
 				72C6173D1AA3951C0085F425 /* FXKeychain-iOS */,
+				1F65C9251D9AF9E6002BAC03 /* FXKeychain-watchOS */,
+				1F65C9331D9AFA79002BAC03 /* FXKeychain-tvOS */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		1F65C9241D9AF9E6002BAC03 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1F65C9321D9AFA79002BAC03 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		72C617191AA3949C0085F425 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -185,6 +278,21 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		1F65C9211D9AF9E6002BAC03 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F65C92E1D9AFA26002BAC03 /* FXKeychain.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1F65C92F1D9AFA79002BAC03 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		72C617161AA3949C0085F425 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -204,6 +312,116 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
+		1F65C92B1D9AF9E6002BAC03 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CODE_SIGN_IDENTITY = "";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_TESTABILITY = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = FXKeychain/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.charcoaldesign.FXKeychain;
+				PRODUCT_NAME = FXKeychain;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		1F65C92C1D9AF9E6002BAC03 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CODE_SIGN_IDENTITY = "";
+				COPY_PHASE_STRIP = NO;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = FXKeychain/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.charcoaldesign.FXKeychain;
+				PRODUCT_NAME = FXKeychain;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				VALIDATE_PRODUCT = YES;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+		1F65C93A1D9AFA79002BAC03 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CODE_SIGN_IDENTITY = "";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_TESTABILITY = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = FXKeychain/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.charcoaldesign.FXKeychain;
+				PRODUCT_NAME = FXKeychain;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Debug;
+		};
+		1F65C93B1D9AFA79002BAC03 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CODE_SIGN_IDENTITY = "";
+				COPY_PHASE_STRIP = NO;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = FXKeychain/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.charcoaldesign.FXKeychain;
+				PRODUCT_NAME = FXKeychain;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 		72C6172F1AA3949C0085F425 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -366,6 +584,22 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		1F65C92D1D9AF9E6002BAC03 /* Build configuration list for PBXNativeTarget "FXKeychain-watchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1F65C92B1D9AF9E6002BAC03 /* Debug */,
+				1F65C92C1D9AF9E6002BAC03 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		1F65C9391D9AFA79002BAC03 /* Build configuration list for PBXNativeTarget "FXKeychain-tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1F65C93A1D9AFA79002BAC03 /* Debug */,
+				1F65C93B1D9AFA79002BAC03 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
 		72C617151AA3949C0085F425 /* Build configuration list for PBXProject "FXKeychain" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (


### PR DESCRIPTION
This PR modifies the Podspec file to add watchOS and tvOS support to FXKeychain, and adds watchOS and tvOS framework targets to the main Xcode project. Everything still builds successfully locally.