### PR TITLE
Added errors when keychain operations fail

### DIFF
--- a/FXKeychain/FXKeychain.h
+++ b/FXKeychain/FXKeychain.h
@@ -75,9 +75,12 @@ typedef NS_ENUM(NSInteger, FXKeychainAccess)
 - (nonnull id)initWithService:(nullable NSString *)service
                   accessGroup:(nullable NSString *)accessGroup;
 
+- (BOOL)setObject:(nullable id)object forKey:(nonnull id)key;
 - (BOOL)setObject:(nullable id)object forKey:(nonnull id)key error:(NSError * _Nullable * _Nullable) error;
 - (BOOL)setObject:(nullable id)object forKeyedSubscript:(nonnull id)key;
+- (BOOL)removeObjectForKey:(nonnull id)key;
 - (BOOL)removeObjectForKey:(nonnull id)key error:(NSError * _Nullable * _Nullable) error;
+- (nullable id)objectForKey:(nonnull id)key;
 - (nullable id)objectForKey:(nonnull id)key error:(NSError * _Nullable * _Nullable) error;
 - (nullable id)objectForKeyedSubscript:(nonnull id)key;
 

--- a/FXKeychain/FXKeychain.h
+++ b/FXKeychain/FXKeychain.h
@@ -78,7 +78,7 @@ typedef NS_ENUM(NSInteger, FXKeychainAccess)
 - (BOOL)setObject:(nullable id)object forKey:(nonnull id)key;
 - (BOOL)setObject:(nullable id)object forKeyedSubscript:(nonnull id)key;
 - (BOOL)removeObjectForKey:(nonnull id)key;
-- (nullable id)objectForKey:(nonnull id)key;
+- (nullable id)objectForKey:(nonnull id)key error:(NSError * _Nullable * _Nullable) error;
 - (nullable id)objectForKeyedSubscript:(nonnull id)key;
 
 @end

--- a/FXKeychain/FXKeychain.h
+++ b/FXKeychain/FXKeychain.h
@@ -75,9 +75,9 @@ typedef NS_ENUM(NSInteger, FXKeychainAccess)
 - (nonnull id)initWithService:(nullable NSString *)service
                   accessGroup:(nullable NSString *)accessGroup;
 
-- (BOOL)setObject:(nullable id)object forKey:(nonnull id)key;
+- (BOOL)setObject:(nullable id)object forKey:(nonnull id)key error:(NSError * _Nullable * _Nullable) error;
 - (BOOL)setObject:(nullable id)object forKeyedSubscript:(nonnull id)key;
-- (BOOL)removeObjectForKey:(nonnull id)key;
+- (BOOL)removeObjectForKey:(nonnull id)key error:(NSError * _Nullable * _Nullable) error;
 - (nullable id)objectForKey:(nonnull id)key error:(NSError * _Nullable * _Nullable) error;
 - (nullable id)objectForKeyedSubscript:(nonnull id)key;
 

--- a/FXKeychain/FXKeychain.h
+++ b/FXKeychain/FXKeychain.h
@@ -59,6 +59,7 @@ typedef NS_ENUM(NSInteger, FXKeychainAccess)
     FXKeychainAccessibleAlwaysThisDeviceOnly
 };
 
+extern NSString * _Nonnull const kFXKeychainErrorDomain;
 
 @interface FXKeychain : NSObject
 

--- a/FXKeychain/FXKeychain.m
+++ b/FXKeychain/FXKeychain.m
@@ -163,7 +163,7 @@
 	return CFBridgingRelease(data);
 }
 
-- (BOOL)setObject:(id)object forKey:(id)key
+- (BOOL)setObject:(id)object forKey:(id)key error:(NSError**) error
 {
     //generate query
     NSMutableDictionary *query = [NSMutableDictionary dictionary];
@@ -179,7 +179,6 @@
     
     //encode object
     NSData *data = nil;
-    NSError *error = nil;
     if ([(id)object isKindOfClass:[NSString class]])
     {
         //check that string data does not represent a binary plist
@@ -187,7 +186,7 @@
         if (![object hasPrefix:@"bplist"] || ![NSPropertyListSerialization propertyListWithData:[object dataUsingEncoding:NSUTF8StringEncoding]
                                                                                         options:NSPropertyListImmutable
                                                                                          format:&format
-                                                                                          error:NULL])
+                                                                                          error:error])
         {
             //safe to encode as a string
             data = [object dataUsingEncoding:NSUTF8StringEncoding];
@@ -200,7 +199,7 @@
         data = [NSPropertyListSerialization dataWithPropertyList:[object FXKeychain_propertyListRepresentation]
                                                           format:NSPropertyListBinaryFormat_v1_0
                                                          options:0
-                                                           error:&error];
+                                                           error:error];
 #if FXKEYCHAIN_USE_NSCODING
         
         //property list encoding failed. try NSCoding
@@ -214,7 +213,7 @@
     }
 
     //fail if object is invalid
-    NSAssert(!object || (object && data), @"FXKeychain failed to encode object for key '%@', error: %@", key, error);
+    NSAssert(!object || (object && data), @"FXKeychain failed to encode object for key '%@', error: %@", key, *error);
 
     if (data)
     {
@@ -278,12 +277,12 @@
 
 - (BOOL)setObject:(id)object forKeyedSubscript:(id)key
 {
-    return [self setObject:object forKey:key];
+    return [self setObject:object forKey:key error:nil];
 }
 
-- (BOOL)removeObjectForKey:(id)key
+- (BOOL)removeObjectForKey:(id)key error:(NSError **)error
 {
-    return [self setObject:nil forKey:key];
+    return [self setObject:nil forKey:key error:error];
 }
 
 - (id)objectForKey:(id)key error:(NSError**) error

--- a/FXKeychain/FXKeychain.m
+++ b/FXKeychain/FXKeychain.m
@@ -163,6 +163,11 @@
 	return CFBridgingRelease(data);
 }
 
+- (BOOL)setObject:(id)object forKey:(id)key
+{
+    return [self setObject:object forKey:key error:nil];
+}
+
 - (BOOL)setObject:(id)object forKey:(id)key error:(NSError**) error
 {
     //generate query
@@ -277,12 +282,22 @@
 
 - (BOOL)setObject:(id)object forKeyedSubscript:(id)key
 {
-    return [self setObject:object forKey:key error:nil];
+    return [self setObject:object forKey:key];
+}
+
+- (BOOL)removeObjectForKey:(id)key
+{
+    return [self removeObjectForKey:key error:nil];
 }
 
 - (BOOL)removeObjectForKey:(id)key error:(NSError **)error
 {
     return [self setObject:nil forKey:key error:error];
+}
+
+- (id)objectForKey:(id)key
+{
+    return [self objectForKey:key error:nil];
 }
 
 - (id)objectForKey:(id)key error:(NSError**) error
@@ -337,7 +352,7 @@
 
 - (id)objectForKeyedSubscript:(id)key
 {
-    return [self objectForKey:key error:nil];
+    return [self objectForKey:key];
 }
 
 @end

--- a/FXKeychain/FXKeychain.m
+++ b/FXKeychain/FXKeychain.m
@@ -286,13 +286,12 @@
     return [self setObject:nil forKey:key];
 }
 
-- (id)objectForKey:(id)key
+- (id)objectForKey:(id)key error:(NSError**) error
 {
     NSData *data = [self dataForKey:key];
     if (data)
     {
         id object = nil;
-        NSError *error = nil;
         NSPropertyListFormat format = NSPropertyListBinaryFormat_v1_0;
         
         //check if data is a binary plist
@@ -302,7 +301,7 @@
             object = [NSPropertyListSerialization propertyListWithData:data
                                                                options:NSPropertyListImmutable
                                                                 format:&format
-                                                                 error:&error];
+                                                                 error:error];
             
             if ([object respondsToSelector:@selector(objectForKey:)] && [(NSDictionary *)object objectForKey:@"$archiver"])
             {
@@ -326,7 +325,7 @@
         }
         if (!object)
         {
-             NSLog(@"FXKeychain failed to decode data for key '%@', error: %@", key, error);
+             NSLog(@"FXKeychain failed to decode data for key '%@', error: %@", key, *error);
         }
         return object;
     }
@@ -339,7 +338,7 @@
 
 - (id)objectForKeyedSubscript:(id)key
 {
-    return [self objectForKey:key];
+    return [self objectForKey:key error:nil];
 }
 
 @end


### PR DESCRIPTION
Since #38 only returns parser errors, this is an expansion that returns errors when keychain operations fail.

I implemented this because I have edge cases where reading from keychain fails because the device is locked or is starting and it is more reliable to check the returned error than to look at the app state.

    NSError *error = nil;
    _authToken = [[FXKeychain defaultKeychain] objectForKey:kAuthTokenKey error:&error];
    if ([error.domain isEqualToString:kFXKeychainErrorDomain] && error.code == errSecInteractionNotAllowed) {
        // unable to load token, retry after a short pause
    }